### PR TITLE
Prevent 3 astronomy images from loading in quick succession

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ class APODWidget extends Widget {
   /**
    * Handle update requests for the widget.
    */
-  async onUpdateRequest(msg: Message): Promise<void> {
+  async onActivateRequest(msg: Message): Promise<void> {
 
     const response = await fetch(`https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY&date=${this.randomDate()}`);
 


### PR DESCRIPTION
This extension has an issue that it quickly loads ~3 astronomy images in quick succession, because the `onUpdateRequest` method automatically fires ~3 times. By changing this to the `onActivateRequest` method, it fixes the issue and loads just one image, while clicking the "Random Astronomy Picture" command in the command pallet still loads a new image.