### PR TITLE
🐛 Fix handling a disposed widget after closing a panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jupyterlab_apod
+# JupyterLab Astronomy Picture of the Day extension
 
 Show a random NASA Astronomy Picture of the Day.
 
@@ -10,7 +10,7 @@ Show a random NASA Astronomy Picture of the Day.
 ## Installation
 
 ```bash
-jupyter labextension install jupyterlab_apod
+jupyter labextension install @jupyterlab/jupyterlab_apod
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/jupyterlab_apod",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "Show a random NASA Astronomy Picture of the Day.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jupyterlab_apod",
+  "name": "@jupyterlab/jupyterlab_apod",
   "version": "0.1.0",
   "description": "Show a random NASA Astronomy Picture of the Day.",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,8 +110,9 @@ function activate(app: JupyterFrontEnd, palette: ICommandPalette, restorer: ILay
   app.commands.addCommand(command, {
     label: 'Random Astronomy Picture',
     execute: () => {
-      if (!widget) {
+      if (!widget || widget.isDisposed) {
         // Create a new widget if one does not exist
+        // or if the previous one was disposed after closing the panel
         const content = new APODWidget();
         widget = new MainAreaWidget({content});
         widget.id = 'apod-jupyterlab';


### PR DESCRIPTION
🐛 Fix handling a disposed widget after closing a panel.

This is the equivalent change from https://github.com/jupyterlab/jupyterlab/pull/8623

For details check that PR.

After merging that PR, this could be merged, and then it would have to be tagged `2.0-05-restore-panel-state` so that the docs referencing it get the updated version.